### PR TITLE
Support additional ACME providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,7 @@ version.
 | `HTTP_IDLE_TIMEOUT`   | The maximum time in seconds that a client can be idle before the connection is closed. | 60 |
 | `HTTP_READ_TIMEOUT`   | The maximum time in seconds that a client can take to send the request headers. | 30 |
 | `HTTP_WRITE_TIMEOUT`  | The maximum time in seconds during which the client must read the response.     | 30 |
+| `ACME_DIRECTORY`      | The URL of the ACME directory to use for SSL certificate provisioning.          | `https://acme-v02.api.letsencrypt.org/directory` (Let's Encrypt production) |
+| `EAB_KID`             | The EAB key identifier to use when provisioning SSL certificates, if required.  | None |
+| `EAB_HMAC_KEY`        | The Base64-encoded EAB HMAC key to use when provisioning SSL certificates, if required. | None |
 | `DEBUG`               | Set to `1` or `true` to enable debug logging.                                   | Disabled |

--- a/internal/config.go
+++ b/internal/config.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"strconv"
 	"time"
+
+	"golang.org/x/crypto/acme"
 )
 
 const (
@@ -20,8 +22,9 @@ const (
 	defaultMaxCacheItemSizeBytes = 1 * MB
 	defaultMaxRequestBody        = 0
 
-	defaultStoragePath    = "./storage/thruster"
-	defaultBadGatewayPage = "./public/502.html"
+	defaultACMEDirectoryURL = acme.LetsEncryptURL
+	defaultStoragePath      = "./storage/thruster"
+	defaultBadGatewayPage   = "./public/502.html"
 
 	defaultHttpPort         = 80
 	defaultHttpsPort        = 443
@@ -42,9 +45,12 @@ type Config struct {
 	XSendfileEnabled      bool
 	MaxRequestBody        int
 
-	SSLDomain      string
-	StoragePath    string
-	BadGatewayPage string
+	SSLDomain        string
+	ACMEDirectoryURL string
+	EAB_KID          string
+	EAB_HMACKey      string
+	StoragePath      string
+	BadGatewayPage   string
 
 	HttpPort         int
 	HttpsPort        int
@@ -75,9 +81,12 @@ func NewConfig() (*Config, error) {
 		XSendfileEnabled:      getEnvBool("X_SENDFILE_ENABLED", true),
 		MaxRequestBody:        getEnvInt("MAX_REQUEST_BODY", defaultMaxRequestBody),
 
-		SSLDomain:      getEnvString("SSL_DOMAIN", ""),
-		StoragePath:    getEnvString("STORAGE_PATH", defaultStoragePath),
-		BadGatewayPage: getEnvString("BAD_GATEWAY_PAGE", defaultBadGatewayPage),
+		SSLDomain:        getEnvString("SSL_DOMAIN", ""),
+		ACMEDirectoryURL: getEnvString("ACME_DIRECTORY", defaultACMEDirectoryURL),
+		EAB_KID:          getEnvString("EAB_KID", ""),
+		EAB_HMACKey:      getEnvString("EAB_HMAC_KEY", ""),
+		StoragePath:      getEnvString("STORAGE_PATH", defaultStoragePath),
+		BadGatewayPage:   getEnvString("BAD_GATEWAY_PAGE", defaultBadGatewayPage),
 
 		HttpPort:         getEnvInt("HTTP_PORT", defaultHttpPort),
 		HttpsPort:        getEnvInt("HTTPS_PORT", defaultHttpsPort),

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -28,6 +28,7 @@ func TestConfig_override_defaults_with_env_vars(t *testing.T) {
 	usingEnvVar(t, "HTTP_READ_TIMEOUT", "5")
 	usingEnvVar(t, "X_SENDFILE_ENABLED", "0")
 	usingEnvVar(t, "DEBUG", "1")
+	usingEnvVar(t, "ACME_DIRECTORY", "https://acme-staging-v02.api.letsencrypt.org/directory")
 
 	c, err := NewConfig()
 	require.NoError(t, err)
@@ -37,6 +38,7 @@ func TestConfig_override_defaults_with_env_vars(t *testing.T) {
 	assert.Equal(t, 5*time.Second, c.HttpReadTimeout)
 	assert.Equal(t, false, c.XSendfileEnabled)
 	assert.Equal(t, slog.LevelDebug, c.LogLevel)
+	assert.Equal(t, "https://acme-staging-v02.api.letsencrypt.org/directory", c.ACMEDirectoryURL)
 }
 
 func TestConfig_override_defaults_with_env_vars_using_prefix(t *testing.T) {


### PR DESCRIPTION
By default, SSL certificates are provisioned using Let's Encrypt's production directory. If the only configuration provided is `SSL_DOMAIN`, that's the behaviour we want.

However, it can also be useful to specify an alternate provider, so we'll expose a few extra environment variable to make that possible:

`ACME_DIRECTORY` can be used to specify a different directory to use. For example, the Let's Encrypt staging environment, or another provider entirely.

Some providers require EAB credentials in order to issue certificates. To support these providers, we allow providing them in `EAB_KID` and `EAB_HMAC_KEY`