### PR TITLE
Fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.0.3 / 2024-03-06
+## v0.1.0 / 2024-03-07
 
 * Build with Go 1.22.1
 * Use stdlib `MaxBytesHandler` for request size limiting


### PR DESCRIPTION
v0.1.0 has been released as https://github.com/basecamp/thruster/commit/7db0b60010ac04a62b3c61038559937a4ce6f8f1 .