### PR TITLE
Add the conditional response with cache entity tag

### DIFF
--- a/internal/cache_handler.go
+++ b/internal/cache_handler.go
@@ -39,7 +39,7 @@ func (h *CacheHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if found {
-		response.WriteCachedResponse(w)
+		response.WriteCachedResponse(w, r)
 		return
 	}
 


### PR DESCRIPTION
* We can reply 304 response with cache to possible to reduce body response if cache entity tag is
equivalent to client side one.
* We can do that to use the request with If-None-Match.
* https://www.rfc-editor.org/rfc/rfc7232#section-2.3

Nginx has the same mechanism can reply the 304 response using cache.

https://github.com/nginx/nginx/blob/e3207a17f084c9eb7905ca0f2cfdb1df088fd165/src/http/ngx_http_upstream.c#L6023-L-6043

https://github.com/nginx/nginx/blob/e3207a17f084c9eb7905ca0f2cfdb1df088fd165/src/http/modules/ngx_http_not_modified_filter_module.c#L86-L105

