### PR TITLE
Clarify HTTP_READ_TIMEOUT documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ environment variables that you can set.
 | `HTTP_PORT`           | The port to listen on for HTTP traffic.                                         | 80 |
 | `HTTPS_PORT`          | The port to listen on for HTTPS traffic.                                        | 443 |
 | `HTTP_IDLE_TIMEOUT`   | The maximum time in seconds that a client can be idle before the connection is closed. | 60 |
-| `HTTP_READ_TIMEOUT`   | The maximum time in seconds that a client can take to send the request headers. | 30 |
+| `HTTP_READ_TIMEOUT`   | The maximum time in seconds that a client can take to send the request headers and body. | 30 |
 | `HTTP_WRITE_TIMEOUT`  | The maximum time in seconds during which the client must read the response.     | 30 |
 | `ACME_DIRECTORY`      | The URL of the ACME directory to use for SSL certificate provisioning.          | `https://acme-v02.api.letsencrypt.org/directory` (Let's Encrypt production) |
 | `EAB_KID`             | The EAB key identifier to use when provisioning SSL certificates, if required.  | None |


### PR DESCRIPTION
The HTTP_READ_TIMEOUT option documentation implies that the timeout is only for request _headers_, which usually will be a small amount of data.

However, if you allow uploads of large amounts of data, the request body might be large and therefore take longer for the request to complete, especially if the upload bandwidth is low.

I've made a very small change to the HTTP_READ_TIMEOUT option documentation to clarify this behaviour so that if you know that you are going to need to cater to this kind of client, you'll know that this timeout might need to be higher