### PR TITLE
Set `stdin` in `UpstreamProcess` to `os.Stdin` (instead of `/dev/null`)

### DIFF
--- a/internal/upstream_process.go
+++ b/internal/upstream_process.go
@@ -22,6 +22,7 @@ func NewUpstreamProcess(name string, arg ...string) *UpstreamProcess {
 }
 
 func (p *UpstreamProcess) Run() (int, error) {
+	p.cmd.Stdin = os.Stdin
 	p.cmd.Stdout = os.Stdout
 	p.cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
Fixes #16 

As explained in the issue, `debug` depends on `irb`, which depends on `reline`. There's a call to [`@@input.winsize`](https://github.com/ruby/reline/blob/155f7047bb7d553d229cdf92d4d221a3e8db3705/lib/reline/ansi.rb#L246) in `reline`:

```ruby
  def self.get_screen_size
    s = @@input.winsize
    return s if s[0] > 0 && s[1] > 0
    s = [ENV["LINES"].to_i, ENV["COLUMNS"].to_i]
    return s if s[0] > 0 && s[1] > 0
    [24, 80]
  rescue Errno::ENOTTY
    [24, 80]
  end
```

The above fails because [`thruster` uses `/dev/null` as stdin](https://cs.opensource.google/go/go/+/refs/tags/go1.22.2:src/os/exec/exec.go;l=178):

```ruby
$ irb

STDIN.winsize
 => [39, 172]

devnull = File.open(File::NULL, "w")
devnull.winsize
(irb):3:in `winsize': Operation not supported by device - /dev/null (Errno::ENODEV)
```