### PR TITLE
Failure to start wrapped process should not panic

### DIFF
--- a/internal/service.go
+++ b/internal/service.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 )
@@ -37,7 +38,8 @@ func (s *Service) Run() int {
 
 	exitCode, err := upstream.Run()
 	if err != nil {
-		panic(err)
+		slog.Error("Failed to start wrapped process", "command", s.config.UpstreamCommand, "args", s.config.UpstreamArgs, "error", err)
+		return 1
 	}
 
 	return exitCode


### PR DESCRIPTION
If we're unable to execute the wrapped process, we should log and error and return a non-zero exit code. However, previously we were triggering a `panic` in this case, which was unnecessary and alarming.

Fixes #22.