### PR TITLE
Use `-trimpath` on dist builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 dist:
 	@for platform in $(PLATFORMS); do \
 		for arch in $(ARCHITECTURES); do \
-			GOOS=$$platform GOARCH=$$arch go build -o dist/thrust-$$platform-$$arch ./cmd/...; \
+			GOOS=$$platform GOARCH=$$arch go build -trimpath -o dist/thrust-$$platform-$$arch ./cmd/...; \
 		done \
 	done
 


### PR DESCRIPTION
When building for release, the source paths are not useful in stacktraces. Adding `-trimpath` excludes them.

Before:
```
goroutine 1 [running]:
github.com/basecamp/thruster/internal.(*Service).Run(0xc00003df28)
	/home/kevin/work/basecamp/thruster/internal/service.go:42 +0x4d0
main.main()
	/home/kevin/work/basecamp/thruster/cmd/thrust/main.go:25 +0xa5
```

After:
```
goroutine 1 [running]:
github.com/basecamp/thruster/internal.(*Service).Run(0xc00003df28)
	github.com/basecamp/thruster/internal/service.go:42 +0x4d0
main.main()
	github.com/basecamp/thruster/cmd/thrust/main.go:25 +0xa5
```
Fixes #21.