### PR TITLE
Set X-Forwarded-* headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Set in the outbound request `X-Forwarded-For` (to the client IP address), `X-Forwarded-Host` (to the host name requested by the client), and `X-Forwarded-Proto` (to "http" or "https" depending on whether the inbound request was made on a TLS-enabled connection) (#29)
+
 ## v0.1.4 / 2024-04-26
 
 * [BREAKING] Rename the `SSL_DOMAIN` env to `TLS_DOMAIN` (#13)


### PR DESCRIPTION
Fixes #25 

For context, you may want to read:
- [NewSingleHostReverseProxy](https://pkg.go.dev/net/http/httputil#NewSingleHostReverseProxy)
- [SetURL](https://pkg.go.dev/net/http/httputil#ProxyRequest.SetURL)
- [SetXForwarded](https://pkg.go.dev/net/http/httputil#ProxyRequest.SetXForwarded)

Manual test:

```bash
cd ~/code/thruster
cd cmd/thrust
make build
```

```bash
cd ~/code
rails new myapp
cd myapp
bin/rails g controller home index
mv ../thruster/bin/thrust .
HTTP_PORT=8080 DEBUG=1 ./thrust bin/rails server
```

```ruby
class HomeController < ApplicationController
  def index
    puts ["Host", request.headers["Host"]].inspect
    puts ["XFor", request.headers["X-Forwarded-For"]].inspect
    puts ["XHost", request.headers["X-Forwarded-Host"]].inspect
    puts ["XProto", request.headers["X-Forwarded-Proto"]].inspect
    head :ok
  end
end
```

```bash
open http://127.0.0.1:3000/home/index
# ["Host", "127.0.0.1:3000"]
# ["XFor", nil]
# ["XHost", nil]
# ["XProto", nil]


http://127.0.0.1:8080/home/index
# ["Host", "127.0.0.1:8080"]
# ["XFor", "127.0.0.1"]
# ["XHost", "127.0.0.1:8080"]
# ["XProto", "http"]
```

```ruby
# config/environments/development.rb
config.hosts << "example.com"
```

```bash
curl -H "Host: example.com" -H "X-Forwarded-For: 1.2.3.4" http://localhost:8080/home/index   
# ["Host", "example.com"]
# ["XFor", "1.2.3.4, 127.0.0.1"]
# ["XHost", "example.com"]
# ["XProto", "http"]
```