### PR TITLE
Fix the description of `HTTP_READ_TIMEOUT` and `HTTP_WRITE_TIMEOUT` in README is reversed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ environment variables that you can set.
 | `HTTP_PORT`           | The port to listen on for HTTP traffic. | 80 |
 | `HTTPS_PORT`          | The port to listen on for HTTPS traffic. | 443 |
 | `HTTP_IDLE_TIMEOUT`   | The maximum time in seconds that a client can be idle before the connection is closed. | 60 |
-| `HTTP_READ_TIMEOUT`   | The maximum time in seconds that a client can take to send the request headers and body. | 30 |
-| `HTTP_WRITE_TIMEOUT`  | The maximum time in seconds during which the client must read the response. | 30 |
+| `HTTP_READ_TIMEOUT`   | The maximum time in seconds during which the client must read the response. | 30 |
+| `HTTP_WRITE_TIMEOUT`  | The maximum time in seconds that a client can take to send the request headers and body. | 30 |
 | `ACME_DIRECTORY`      | The URL of the ACME directory to use for TLS certificate provisioning. | `https://acme-v02.api.letsencrypt.org/directory` (Let's Encrypt production) |
 | `EAB_KID`             | The EAB key identifier to use when provisioning TLS certificates, if required. | None |
 | `EAB_HMAC_KEY`        | The Base64-encoded EAB HMAC key to use when provisioning TLS certificates, if required. | None |


### PR DESCRIPTION
Fix README.