### PR TITLE
Add JRuby supoort by copy all binary exectuables on pure Ruby platform

### DIFF
--- a/exe/thrust
+++ b/exe/thrust
@@ -1,11 +1,15 @@
 #! /usr/bin/env ruby
 
-PLATFORM = [ :cpu, :os ].map { |m| Gem::Platform.local.send(m) }.join("-")
-EXECUTABLE = File.expand_path(File.join(__dir__, PLATFORM, "thrust"))
+EXECUTE_PLATFORM = if RUBY_PLATFORM == 'java'
+  %w[target_cpu target_os].map { |m| RbConfig::CONFIG[m] }.join("-")
+else
+  [ :cpu, :os ].map { |m| Gem::Platform.local.send(m) }.join("-")
+end
+EXECUTABLE = File.expand_path(File.join(__dir__, EXECUTE_PLATFORM, "thrust"))
 
 if File.exist?(EXECUTABLE)
   exec(EXECUTABLE, *ARGV)
 else
-  STDERR.puts("ERROR: Unsupported platform: #{PLATFORM}")
+  STDERR.puts("ERROR: Unsupported platform: #{EXECUTE_PLATFORM}")
   exit 1
 end


### PR DESCRIPTION
For JRuby users, I just mod following ruby files to make this gem can run in JRuby

- `exe/thrust` : Use RbConfig to make sure what kind of dist binary should use.
- `rakelib/package.rake`: Package all dist binaries for pure Ruby platform.

I make this PR just because I want to make some of my projects can transform between CRuby and JRuby, please let me know if there is any possible concerns.

Thanks,