### PR TITLE
Add FreeBSD support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build dist test bench clean
 
-PLATFORMS = linux darwin
+PLATFORMS = linux darwin freebsd
 ARCHITECTURES = amd64 arm64
 
 build:

--- a/rakelib/package.rake
+++ b/rakelib/package.rake
@@ -5,6 +5,8 @@ NATIVE_PLATFORMS = {
   "x86_64-darwin" => "dist/thrust-darwin-amd64",
   "x86_64-linux" => "dist/thrust-linux-amd64",
   "aarch64-linux" => "dist/thrust-linux-arm64",
+  "x86_64-freebsd" => "dist/thrust-freebsd-amd64",
+  "aarch64-freebsd" => "dist/thrust-freebsd-arm64",
 }
 
 BASE_GEMSPEC = Bundler.load_gemspec("thruster.gemspec")


### PR DESCRIPTION
Resolve the `ERROR: Unsupported platform` error that occurs when running
thruster on FreeBSD by compiling the necessary binaries.
