### PR TITLE
Set x-sendfile header in rails config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg
 /exe/
 !/exe/thrust
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/lib/thruster/engine.rb
+++ b/lib/thruster/engine.rb
@@ -1,0 +1,9 @@
+module Thruster
+  class Engine < ::Rails::Engine
+    initializer "thruster.x_send_file" do
+      if Rails.env.production?
+        config.action_dispatch.x_sendfile_header = "X-Sendfile"
+      end
+    end
+  end
+end

--- a/thruster.gemspec
+++ b/thruster.gemspec
@@ -18,4 +18,6 @@ Gem::Specification.new do |s|
   s.files = Dir[ "{lib}/**/*", "MIT-LICENSE", "README.md" ]
   s.bindir = "exe"
   s.executables << "thrust"
+
+  s.add_dependency "railties", ">= 7.2"
 end


### PR DESCRIPTION
Hey there!

Been messing around with some image stuff and found that out of the box x-sendfile wasnt being used. In a controller i have:
```ruby
    send_file file.path,
      type: content_type || DEFAULT_SEND_FILE_TYPE,
      disposition: disposition || DEFAULT_SEND_FILE_DISPOSITION,
      file_name: params[:filename]
```
and then i put some bindings inside Rake::Sendfile and it never was getting called. I then set `config.action_dispatch.x_sendfile_header = "X-Sendfile"` in config/application.rb and it started getting hit. So this pr sets the header by default in a railtie so people dont have to set it.

But after setting this, rack sets the content length to 0 and the file never gets loaded. (im assuming thruster comes back through and does the download but doesnt seem to be).  I've attached a screenshot of the network hoping that helps. Am I miss configuring something here to enable x-sendfile usage? I'll also note im doing this with the disk adapter of active storage if that matters. 

Thanks!

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/c177c24f-1959-4353-85d0-a53f35811746">
