### PR TITLE
Bump go version for CVE's

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/thruster
 
-go 1.22.1
+go 1.22.7
 
 require (
 	github.com/klauspost/compress v1.17.4


### PR DESCRIPTION
Update go to `1.22.7` to remediate CVE's 

<img width="1189" alt="Screenshot 2024-10-24 at 21 15 02" src="https://github.com/user-attachments/assets/068ed9cd-3f64-4ca6-9671-c2ceeaace3c6">
