### PR TITLE
Teach thruster to optionally not log requests

### DIFF
--- a/internal/config.go
+++ b/internal/config.go
@@ -102,7 +102,7 @@ func NewConfig() (*Config, error) {
 		HttpWriteTimeout: getEnvDuration("HTTP_WRITE_TIMEOUT", defaultHttpWriteTimeout),
 
 		LogLevel:    logLevel,
-		LogRequests: getEnvBool("LOG_REQUESTS", true),
+		LogRequests: getEnvBool("LOG_REQUESTS", defaultLogRequests),
 	}
 
 	config.ForwardHeaders = getEnvBool("FORWARD_HEADERS", !config.HasTLS())

--- a/internal/config.go
+++ b/internal/config.go
@@ -33,7 +33,8 @@ const (
 	defaultHttpReadTimeout  = 30 * time.Second
 	defaultHttpWriteTimeout = 30 * time.Second
 
-	defaultLogLevel = slog.LevelInfo
+	defaultLogLevel    = slog.LevelInfo
+	defaultLogRequests = true
 )
 
 type Config struct {
@@ -62,7 +63,8 @@ type Config struct {
 
 	ForwardHeaders bool
 
-	LogLevel slog.Level
+	LogLevel    slog.Level
+	LogRequests bool
 }
 
 func NewConfig() (*Config, error) {
@@ -99,7 +101,8 @@ func NewConfig() (*Config, error) {
 		HttpReadTimeout:  getEnvDuration("HTTP_READ_TIMEOUT", defaultHttpReadTimeout),
 		HttpWriteTimeout: getEnvDuration("HTTP_WRITE_TIMEOUT", defaultHttpWriteTimeout),
 
-		LogLevel: logLevel,
+		LogLevel:    logLevel,
+		LogRequests: getEnvBool("LOG_REQUESTS", true),
 	}
 
 	config.ForwardHeaders = getEnvBool("FORWARD_HEADERS", !config.HasTLS())

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -116,6 +116,7 @@ func TestConfig_override_defaults_with_env_vars(t *testing.T) {
 	usingEnvVar(t, "GZIP_COMPRESSION_ENABLED", "0")
 	usingEnvVar(t, "DEBUG", "1")
 	usingEnvVar(t, "ACME_DIRECTORY", "https://acme-staging-v02.api.letsencrypt.org/directory")
+	usingEnvVar(t, "LOG_REQUESTS", "false")
 
 	c, err := NewConfig()
 	require.NoError(t, err)
@@ -127,6 +128,7 @@ func TestConfig_override_defaults_with_env_vars(t *testing.T) {
 	assert.Equal(t, false, c.GzipCompressionEnabled)
 	assert.Equal(t, slog.LevelDebug, c.LogLevel)
 	assert.Equal(t, "https://acme-staging-v02.api.letsencrypt.org/directory", c.ACMEDirectoryURL)
+	assert.Equal(t, false, c.LogRequests)
 }
 
 func TestConfig_override_defaults_with_env_vars_using_prefix(t *testing.T) {
@@ -136,6 +138,7 @@ func TestConfig_override_defaults_with_env_vars_using_prefix(t *testing.T) {
 	usingEnvVar(t, "THRUSTER_HTTP_READ_TIMEOUT", "5")
 	usingEnvVar(t, "THRUSTER_X_SENDFILE_ENABLED", "0")
 	usingEnvVar(t, "THRUSTER_DEBUG", "1")
+	usingEnvVar(t, "THRUSTER_LOG_REQUESTS", "0")
 
 	c, err := NewConfig()
 	require.NoError(t, err)
@@ -145,6 +148,7 @@ func TestConfig_override_defaults_with_env_vars_using_prefix(t *testing.T) {
 	assert.Equal(t, 5*time.Second, c.HttpReadTimeout)
 	assert.Equal(t, false, c.XSendfileEnabled)
 	assert.Equal(t, slog.LevelDebug, c.LogLevel)
+	assert.Equal(t, false, c.LogRequests)
 }
 
 func TestConfig_prefixed_variables_take_precedence_over_non_prefixed(t *testing.T) {

--- a/internal/handler_test.go
+++ b/internal/handler_test.go
@@ -293,5 +293,6 @@ func handlerOptions(targetUrl string) HandlerOptions {
 		maxCacheableResponseBody: 1024,
 		badGatewayPage:           "",
 		forwardHeaders:           true,
+		logRequests:              true,
 	}
 }

--- a/internal/service.go
+++ b/internal/service.go
@@ -27,6 +27,7 @@ func (s *Service) Run() int {
 		maxRequestBody:           s.config.MaxRequestBody,
 		badGatewayPage:           s.config.BadGatewayPage,
 		forwardHeaders:           s.config.ForwardHeaders,
+		logRequests:              s.config.LogRequests,
 	}
 
 	handler := NewHandler(handlerOptions)


### PR DESCRIPTION
Adds an environment variable, $LOG_REQUESTS, that when set to a falsey value will not add the logging middleware to the HTTP handler, disabling request logs. Other logs, like the startup messages, are left alone.

Closes #49.