### PR TITLE
improve test coverage

### DIFF
--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -156,6 +156,20 @@ func TestConfig_prefixed_variables_take_precedence_over_non_prefixed(t *testing.
 	assert.Equal(t, 4000, c.TargetPort)
 }
 
+func TestConfig_defaults_are_used_if_strconv_fails(t *testing.T) {
+	usingProgramArgs(t, "thruster", "echo", "hello")
+	usingEnvVar(t, "TARGET_PORT", "should-be-an-int")
+	usingEnvVar(t, "HTTP_IDLE_TIMEOUT", "should-be-a-duration")
+	usingEnvVar(t, "X_SENDFILE_ENABLED", "should-be-a-bool")
+
+	c, err := NewConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, 3000, c.TargetPort)
+	assert.Equal(t, 60*time.Second, c.HttpIdleTimeout)
+	assert.Equal(t, true, c.XSendfileEnabled)
+}
+
 func TestConfig_return_error_when_no_upstream_command(t *testing.T) {
 	usingProgramArgs(t, "thruster")
 

--- a/internal/fixtures/502.html
+++ b/internal/fixtures/502.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><title>Something went wrong</title></head>
+  <body>Something went wrong.</body>
+</html>

--- a/internal/handler_test.go
+++ b/internal/handler_test.go
@@ -155,6 +155,41 @@ func TestHandlerMaxRequestBody(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestHandler_bad_gateway_response(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("backend error")
+	}))
+	defer upstream.Close()
+
+	options := handlerOptions(upstream.URL)
+	h := NewHandler(options)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/", bytes.NewReader([]byte("hello there")))
+	h.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Equal(t, "", w.Header().Get("Content-Type"))
+	assert.Equal(t, "", w.Body.String())
+}
+
+func TestHandler_serve_custom_bad_gateway_page(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("backend error")
+	}))
+	defer upstream.Close()
+
+	options := handlerOptions(upstream.URL)
+	options.badGatewayPage = fixturePath("502.html")
+	h := NewHandler(options)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("POST", "/", bytes.NewReader([]byte("hello there")))
+	h.ServeHTTP(w, r)
+	assert.Equal(t, http.StatusBadGateway, w.Code)
+	assert.Equal(t, "text/html", w.Header().Get("Content-Type"))
+	assert.Equal(t, string(fixtureContent("502.html")), w.Body.String())
+}
+
 func TestHandlerPreserveInboundHostHeaderWhenProxying(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "example.org", r.Host)


### PR DESCRIPTION
Viewing coverage locally like so

```
go test -v -coverprofile cover.out ./... && go tool cover -html cover.out -o cover.html && open cover.html
```

<details><summary>internal/config.go</summary>
<p>

Before:

![image](https://github.com/user-attachments/assets/c6170f41-be36-496c-ad5f-a521fad976b0)

After: 100%

</p>
</details> 

<details><summary>internal/proxy_handler.go</summary>
<p>

Before:

![image](https://github.com/user-attachments/assets/b5f30d2e-9672-4664-a438-70840c94ba77)

After: 100%


</p>
</details> 

