### PR TITLE
Build with Go 1.23.6 (addresses 3 CVEs)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/thruster
 
-go 1.23.3
+go 1.23.6
 
 require (
 	github.com/klauspost/compress v1.17.4


### PR DESCRIPTION
Fixes Issue #64 

See https://go.dev/doc/devel/release#go1.23.minor for changes in 1.23.5 and 1.23.6 