### PR TITLE
Build with Go 1.23.7 (addresses CVE)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/thruster
 
-go 1.23.6
+go 1.23.7
 
 require (
 	github.com/klauspost/compress v1.17.4


### PR DESCRIPTION
Fixes CVE mentioned in #68
