### PR TITLE
Add X-Request-Start header middleware

### DIFF
--- a/internal/handler.go
+++ b/internal/handler.go
@@ -31,6 +31,7 @@ func NewHandler(options HandlerOptions) http.Handler {
 		handler = http.MaxBytesHandler(handler, int64(options.maxRequestBody))
 	}
 
+	handler = NewRequestStartMiddleware(handler)
 	handler = NewLoggingMiddleware(slog.Default(), handler)
 
 	return handler

--- a/internal/request_start_middleware.go
+++ b/internal/request_start_middleware.go
@@ -8,8 +8,10 @@ import (
 
 func NewRequestStartMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		timestamp := time.Now().UnixMilli()
-		r.Header.Set("X-Request-Start", fmt.Sprintf("t=%d", timestamp))
+		if r.Header.Get("X-Request-Start") == "" {
+			timestamp := time.Now().UnixMilli()
+			r.Header.Set("X-Request-Start", fmt.Sprintf("t=%d", timestamp))
+		}
 		next.ServeHTTP(w, r)
 	})
 }

--- a/internal/request_start_middleware.go
+++ b/internal/request_start_middleware.go
@@ -1,0 +1,15 @@
+package internal
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+func NewRequestStartMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timestamp := time.Now().UnixMilli()
+		r.Header.Set("X-Request-Start", fmt.Sprintf("t=%d", timestamp))
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/request_start_middleware_test.go
+++ b/internal/request_start_middleware_test.go
@@ -33,3 +33,20 @@ func TestRequestStartMiddleware(t *testing.T) {
 	assert.GreaterOrEqual(t, timestamp, before)
 	assert.LessOrEqual(t, timestamp, after)
 }
+
+func TestRequestStartMiddlewareDoesNotOverwriteExistingHeader(t *testing.T) {
+	existingHeader := "t=1234567890"
+	var capturedHeader string
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("X-Request-Start")
+	})
+
+	middleware := NewRequestStartMiddleware(nextHandler)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-Start", existingHeader)
+	w := httptest.NewRecorder()
+	middleware.ServeHTTP(w, req)
+
+	assert.Equal(t, existingHeader, capturedHeader)
+}

--- a/internal/request_start_middleware_test.go
+++ b/internal/request_start_middleware_test.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestStartMiddleware(t *testing.T) {
+	var capturedHeader string
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("X-Request-Start")
+	})
+
+	middleware := NewRequestStartMiddleware(nextHandler)
+
+	before := time.Now().UnixMilli()
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	middleware.ServeHTTP(w, req)
+	after := time.Now().UnixMilli()
+
+	assert.NotEmpty(t, capturedHeader)
+	assert.Regexp(t, `^t=\d+$`, capturedHeader)
+
+	timestampStr := capturedHeader[2:]
+	timestamp, err := strconv.ParseInt(timestampStr, 10, 64)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, timestamp, before)
+	assert.LessOrEqual(t, timestamp, after)
+}


### PR DESCRIPTION
Personally, I'm of the belief that everyone should be measuring their request queue times. To do that, we need something in front of the application stamping requests with an `X-Request-Start` header, so that our application can read that and calculate time spent queueing.

This is usually done in nginx/some other reverse proxy for those using those projects.

This header and format is a common convention and used by New Relic, Datadog and others. If you use any of these APMs and incoming requests start carrying this header, they'll automatically start calculating request queue time.

I did not include a config option because I felt it was unnecessary. 


