### PR TITLE
Ensure all response writers are flushable

### DIFF
--- a/internal/cacheable_response.go
+++ b/internal/cacheable_response.go
@@ -75,6 +75,13 @@ func (c *CacheableResponse) WriteHeader(statusCode int) {
 	c.headersWritten = true
 }
 
+func (c *CacheableResponse) Flush() {
+	flusher, ok := c.responseWriter.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}
+
 func (c *CacheableResponse) CacheStatus() (bool, time.Time) {
 	if c.stasher.Overflowed() {
 		return false, time.Time{}

--- a/internal/logging_middleware.go
+++ b/internal/logging_middleware.go
@@ -87,3 +87,10 @@ func (r *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	}
 	return con, rw, err
 }
+
+func (r *responseWriter) Flush() {
+	flusher, ok := r.ResponseWriter.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}

--- a/internal/sendfile_handler.go
+++ b/internal/sendfile_handler.go
@@ -79,6 +79,13 @@ func (w *sendfileWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return hijacker.Hijack()
 }
 
+func (w *sendfileWriter) Flush() {
+	flusher, ok := w.w.(http.Flusher)
+	if ok {
+		flusher.Flush()
+	}
+}
+
 func (w *sendfileWriter) sendingFilename() string {
 	return w.w.Header().Get("X-Sendfile")
 }


### PR DESCRIPTION
When using custom response writers in middleware, we need to ensure they all implement `http.Flusher`. Otherwise, the resulting handler will not be flushable, which means the reverse proxy has no way to flush response content to the client.

Not being able to flush content breaks response types like SSE, which depend on sending chunked data as it happens, rather than buffering it all to the end.

Fixes #47