### PR TITLE
Add H2C support behind H2C_ENABLED feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ environment variables that you can set.
 | `HTTP_IDLE_TIMEOUT`         | The maximum time in seconds that a client can be idle before the connection is closed. | 60 |
 | `HTTP_READ_TIMEOUT`         | The maximum time in seconds that a client can take to send the request headers and body. | 30 |
 | `HTTP_WRITE_TIMEOUT`        | The maximum time in seconds during which the client must read the response. | 30 |
+| `H2C_ENABLED`               | Set to `1` or `true` to enable h2c (http/2 cleartext) | Disabled |
 | `ACME_DIRECTORY`            | The URL of the ACME directory to use for TLS certificate provisioning. | `https://acme-v02.api.letsencrypt.org/directory` (Let's Encrypt production) |
 | `EAB_KID`                   | The EAB key identifier to use when provisioning TLS certificates, if required. | None |
 | `EAB_HMAC_KEY`              | The Base64-encoded EAB HMAC key to use when provisioning TLS certificates, if required. | None |

--- a/internal/config.go
+++ b/internal/config.go
@@ -33,6 +33,8 @@ const (
 	defaultHttpReadTimeout  = 30 * time.Second
 	defaultHttpWriteTimeout = 30 * time.Second
 
+	defaultH2CEnabled = false
+
 	defaultLogLevel    = slog.LevelInfo
 	defaultLogRequests = true
 )
@@ -60,6 +62,8 @@ type Config struct {
 	HttpIdleTimeout  time.Duration
 	HttpReadTimeout  time.Duration
 	HttpWriteTimeout time.Duration
+
+	H2CEnabled bool
 
 	ForwardHeaders bool
 
@@ -100,6 +104,8 @@ func NewConfig() (*Config, error) {
 		HttpIdleTimeout:  getEnvDuration("HTTP_IDLE_TIMEOUT", defaultHttpIdleTimeout),
 		HttpReadTimeout:  getEnvDuration("HTTP_READ_TIMEOUT", defaultHttpReadTimeout),
 		HttpWriteTimeout: getEnvDuration("HTTP_WRITE_TIMEOUT", defaultHttpWriteTimeout),
+
+		H2CEnabled: getEnvBool("H2C_ENABLED", defaultH2CEnabled),
 
 		LogLevel:    logLevel,
 		LogRequests: getEnvBool("LOG_REQUESTS", defaultLogRequests),

--- a/internal/server.go
+++ b/internal/server.go
@@ -102,11 +102,21 @@ func (s *Server) externalAccountBinding() *acme.ExternalAccountBinding {
 }
 
 func (s *Server) defaultHttpServer(addr string) *http.Server {
+	protocols := new(http.Protocols)
+	protocols.SetHTTP1(true)
+	protocols.SetHTTP2(true)
+
+	if s.config.H2CEnabled {
+		// Enable h2c support
+		protocols.SetUnencryptedHTTP2(true)
+	}
+
 	return &http.Server{
 		Addr:         addr,
 		IdleTimeout:  s.config.HttpIdleTimeout,
 		ReadTimeout:  s.config.HttpReadTimeout,
 		WriteTimeout: s.config.HttpWriteTimeout,
+		Protocols:    protocols,
 	}
 }
 


### PR DESCRIPTION
This adds support for http/2 cleartext (h2c) where prior knowledge is known about the server so an upgrade request (where potential memory consumption issues are not possible).

To quote [this issues](https://github.com/golang/go/issues/72039):

> Go 1.24's net/http package includes support for HTTP/2 with prior knowledge. It does not include support for the deprecated protocol upgrade mechanism, and we have no plans to add such support.

Good news!

This change is useful for those who run rails apps behind Cloud Run (or AWS) where some limits may apply to apps (like max file size) unless you run http/2 and enable h2c in the cloud provider settings.

Snippet taken from: https://github.com/basecamp/thruster/issues/72

Applied feedback from: https://github.com/basecamp/thruster/pull/3