### PR TITLE
Log error and exit if unable to bind ports

### DIFF
--- a/internal/service.go
+++ b/internal/service.go
@@ -34,7 +34,9 @@ func (s *Service) Run() int {
 	server := NewServer(s.config, handler)
 	upstream := NewUpstreamProcess(s.config.UpstreamCommand, s.config.UpstreamArgs...)
 
-	server.Start()
+	if err := server.Start(); err != nil {
+		return 1
+	}
 	defer server.Stop()
 
 	s.setEnvironment()


### PR DESCRIPTION
When run without permissions to bind to the HTTP and/or HTTPS ports, previously the server would fail silently, which can be confusing. Now if this occurs we will instead log the error and exit.

Fixes #65