### PR TITLE
Add close response body in server test

### DIFF
--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -45,12 +45,10 @@ func TestServerEnabledH2CWhenConfigProvided(t *testing.T) {
 
 func TestServerCanMakeAnEndToEndH2CRequestWhenEnabled(t *testing.T) {
 	resp, err := makeRoundTripH2cRequest(t, true)
-	t.Cleanup(func() {
-		resp.Body.Close()
-	})
-	_, _ = io.Copy(io.Discard, resp.Body)
-
 	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	assert.Equal(t, "HTTP/2.0", resp.Proto)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)


### PR DESCRIPTION
Added code to close the response body in the server test. Please merge if it looks good. 
I followed the implementation in this PR: https://github.com/basecamp/kamal-proxy/pull/73