### PR TITLE
Return correct exit code when process signalled

### DIFF
--- a/internal/upstream_process_test.go
+++ b/internal/upstream_process_test.go
@@ -19,17 +19,20 @@ func TestUpstreamProcess(t *testing.T) {
 	t.Run("signal a process to stop it", func(t *testing.T) {
 		var exitCode int
 		var err error
+		done := make(chan struct{})
 
 		p := NewUpstreamProcess("sleep", "10")
 
 		go func() {
 			exitCode, err = p.Run()
+			close(done)
 		}()
 
 		<-p.Started
 		assert.NoError(t, p.Signal(syscall.SIGTERM))
+		<-done
 
 		assert.NoError(t, err)
-		assert.Equal(t, 0, exitCode)
+		assert.Equal(t, 128+int(syscall.SIGTERM), exitCode)
 	})
 }


### PR DESCRIPTION
If either the main process or upstream process is terminated with a signal, we now return the expected `128+signal` status code.

Previously we were returning `-1`, which breaks convention.