### PR TITLE
Fall back to any installed thruster gem when platform binary is missing

### DIFF
--- a/exe/thrust
+++ b/exe/thrust
@@ -1,11 +1,26 @@
 #! /usr/bin/env ruby
 
 PLATFORM = [ :cpu, :os ].map { |m| Gem::Platform.local.send(m) }.join("-")
-EXECUTABLE = File.expand_path(File.join(__dir__, PLATFORM, "thrust"))
 
-if File.exist?(EXECUTABLE)
-  exec(EXECUTABLE, *ARGV)
+# The binary lives in exe/<platform>/thrust within the platform-specific gem.
+# If Bundler resolved the non-platform gem, look for it in any other installed
+# thruster gem that does have the binary (e.g. a separately-installed platform gem).
+def find_executable(platform)
+  candidates = [ File.expand_path(File.join(__dir__, platform, "thrust")) ]
+
+  Gem::Specification.each do |spec|
+    if spec.name == "thruster"
+      candidates << File.join(spec.gem_dir, "exe", platform, "thrust")
+    end
+  end
+
+  candidates.find { |path| File.exist?(path) }
+end
+
+if executable = find_executable(PLATFORM)
+  exec(executable, *ARGV)
 else
-  STDERR.puts("ERROR: Unsupported platform: #{PLATFORM}")
+  STDERR.puts "ERROR: Thruster binary not found for platform #{PLATFORM}."
+  STDERR.puts "Make sure the platform-specific gem is installed: gem install thruster --platform #{PLATFORM}"
   exit 1
 end


### PR DESCRIPTION
## Problem

`exe/thrust` looks for the Go binary at `exe/<platform>/thrust` relative to its own location. That binary only ships in the platform-specific gem (e.g. `thruster-0.1.18-x86_64-linux`). If Bundler resolves the non-platform gem instead — which can happen when updating the lock file on a machine where the platform gem was already installed — the script fails with a misleading "Unsupported platform" error even though the platform is perfectly supported.

## Fix

Before giving up, search all installed `thruster` gems for the platform binary. If a platform-specific gem is installed alongside the base gem, its binary is used transparently.

Also improves the error message to tell users exactly what to do (`gem install thruster --platform <platform>`) rather than implying their platform isn't supported.