### PR TITLE
Validate Host header against TLS domains in HTTP→HTTPS redirect

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
+	"golang.org/x/net/idna"
 )
 
 type Server struct {
@@ -35,7 +36,7 @@ func (s *Server) Start() error {
 		manager := s.certManager()
 
 		s.httpServer = s.defaultHttpServer(httpAddress)
-		s.httpServer.Handler = manager.HTTPHandler(http.HandlerFunc(httpRedirectHandler))
+		s.httpServer.Handler = manager.HTTPHandler(httpRedirectHandler(s.config.TLSDomains))
 
 		s.httpsServer = s.defaultHttpServer(httpsAddress)
 		s.httpsServer.TLSConfig = manager.TLSConfig()
@@ -142,14 +143,54 @@ func (s *Server) defaultHttpServer(addr string) *http.Server {
 	}
 }
 
-func httpRedirectHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Connection", "close")
-
-	host, _, err := net.SplitHostPort(r.Host)
-	if err != nil {
-		host = r.Host
+// httpRedirectHandler returns an HTTP handler that redirects allowed hosts to HTTPS.
+// Precondition: tlsDomains must be non-empty. This function is only called inside the
+// HasTLS() branch, which guarantees at least one TLS domain is configured.
+func httpRedirectHandler(tlsDomains []string) http.HandlerFunc {
+	// Normalize configured domains to ASCII (Punycode) for consistent comparison,
+	// matching the normalization that autocert.HostWhitelist applies via idna.Lookup.ToASCII.
+	// Domains that fail normalization are skipped, matching autocert behavior.
+	normalizedDomains := make([]string, 0, len(tlsDomains))
+	for _, d := range tlsDomains {
+		ascii, err := idna.Lookup.ToASCII(d)
+		if err != nil {
+			slog.Warn("Skipping TLS domain that failed IDNA normalization", "domain", d, "error", err)
+			continue
+		}
+		normalizedDomains = append(normalizedDomains, ascii)
 	}
 
-	url := "https://" + host + r.URL.RequestURI()
-	http.Redirect(w, r, url, http.StatusMovedPermanently)
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "close")
+
+		// Strip port from host. The redirect URL omits the port intentionally
+		// because HTTPS defaults to 443.
+		host, _, err := net.SplitHostPort(r.Host)
+		if err != nil {
+			host = r.Host
+		}
+
+		normalizedHost, err := idna.Lookup.ToASCII(host)
+		if err != nil {
+			slog.Warn("Rejecting request with host that failed IDNA normalization", "host", host, "error", err)
+			http.Error(w, "Misdirected Request", http.StatusMisdirectedRequest)
+			return
+		}
+
+		allowed := false
+		for _, domain := range normalizedDomains {
+			if normalizedHost == domain {
+				allowed = true
+				break
+			}
+		}
+
+		if !allowed {
+			http.Error(w, "Misdirected Request", http.StatusMisdirectedRequest)
+			return
+		}
+
+		url := "https://" + normalizedHost + r.URL.RequestURI()
+		http.Redirect(w, r, url, http.StatusMovedPermanently)
+	}
 }

--- a/internal/server.go
+++ b/internal/server.go
@@ -19,6 +19,7 @@ type Server struct {
 	handler     http.Handler
 	httpServer  *http.Server
 	httpsServer *http.Server
+	manager     *autocert.Manager
 }
 
 func NewServer(config *Config, handler http.Handler) *Server {
@@ -33,13 +34,13 @@ func (s *Server) Start() error {
 	httpsAddress := fmt.Sprintf(":%d", s.config.HttpsPort)
 
 	if s.config.HasTLS() {
-		manager := s.certManager()
+		s.manager = s.certManager()
 
 		s.httpServer = s.defaultHttpServer(httpAddress)
-		s.httpServer.Handler = manager.HTTPHandler(httpRedirectHandler(s.config.TLSDomains))
+		s.httpServer.Handler = s.manager.HTTPHandler(http.HandlerFunc(s.httpRedirectHandler))
 
 		s.httpsServer = s.defaultHttpServer(httpsAddress)
-		s.httpsServer.TLSConfig = manager.TLSConfig()
+		s.httpsServer.TLSConfig = s.manager.TLSConfig()
 		s.httpsServer.Handler = s.handler
 
 		httpListener, err := net.Listen("tcp", httpAddress)
@@ -61,6 +62,7 @@ func (s *Server) Start() error {
 		return nil
 	} else {
 		s.httpsServer = nil
+		s.manager = nil
 		s.httpServer = s.defaultHttpServer(httpAddress)
 		s.httpServer.Handler = s.handler
 
@@ -143,57 +145,24 @@ func (s *Server) defaultHttpServer(addr string) *http.Server {
 	}
 }
 
-// httpRedirectHandler returns an HTTP handler that redirects allowed hosts to HTTPS.
-// Precondition: tlsDomains must be non-empty. This function is only called inside the
-// HasTLS() branch, which guarantees at least one TLS domain is configured.
-// If all configured domains fail IDNA normalization, the normalized allowlist will be
-// empty and all requests will receive 421. This is intentional: if no domain can be
-// normalized, no valid certificate can be issued either, so redirecting would be wrong.
-func httpRedirectHandler(tlsDomains []string) http.HandlerFunc {
-	// Normalize configured domains to ASCII (Punycode) for consistent comparison,
-	// matching the normalization that autocert.HostWhitelist applies via idna.Lookup.ToASCII.
-	// Domains that fail normalization are skipped, matching autocert behavior.
-	normalizedDomains := make([]string, 0, len(tlsDomains))
-	for _, d := range tlsDomains {
-		ascii, err := idna.Lookup.ToASCII(d)
-		if err != nil {
-			slog.Warn("Skipping TLS domain that failed IDNA normalization", "domain", d, "error", err)
-			continue
-		}
-		normalizedDomains = append(normalizedDomains, ascii)
+func (s *Server) httpRedirectHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Connection", "close")
+
+	host, _, err := net.SplitHostPort(r.Host)
+	if err != nil {
+		host = r.Host
 	}
 
-	return func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Connection", "close")
-
-		// Strip port from host. The redirect URL omits the port intentionally
-		// because HTTPS defaults to 443.
-		host, _, err := net.SplitHostPort(r.Host)
-		if err != nil {
-			host = r.Host
-		}
-
-		normalizedHost, err := idna.Lookup.ToASCII(host)
-		if err != nil {
-			slog.Debug("Rejecting request with host that failed IDNA normalization", "host", host, "error", err)
-			http.Error(w, "Misdirected Request", http.StatusMisdirectedRequest)
-			return
-		}
-
-		allowed := false
-		for _, domain := range normalizedDomains {
-			if normalizedHost == domain {
-				allowed = true
-				break
-			}
-		}
-
-		if !allowed {
-			http.Error(w, "Misdirected Request", http.StatusMisdirectedRequest)
-			return
-		}
-
-		url := "https://" + normalizedHost + r.URL.RequestURI()
-		http.Redirect(w, r, url, http.StatusMovedPermanently)
+	if host, err = idna.Lookup.ToASCII(host); err != nil {
+		http.Error(w, http.StatusText(http.StatusMisdirectedRequest), http.StatusMisdirectedRequest)
+		return
 	}
+
+	if s.manager.HostPolicy(r.Context(), host) != nil {
+		http.Error(w, http.StatusText(http.StatusMisdirectedRequest), http.StatusMisdirectedRequest)
+		return
+	}
+
+	url := "https://" + host + r.URL.RequestURI()
+	http.Redirect(w, r, url, http.StatusMovedPermanently)
 }

--- a/internal/server.go
+++ b/internal/server.go
@@ -146,6 +146,9 @@ func (s *Server) defaultHttpServer(addr string) *http.Server {
 // httpRedirectHandler returns an HTTP handler that redirects allowed hosts to HTTPS.
 // Precondition: tlsDomains must be non-empty. This function is only called inside the
 // HasTLS() branch, which guarantees at least one TLS domain is configured.
+// If all configured domains fail IDNA normalization, the normalized allowlist will be
+// empty and all requests will receive 421. This is intentional: if no domain can be
+// normalized, no valid certificate can be issued either, so redirecting would be wrong.
 func httpRedirectHandler(tlsDomains []string) http.HandlerFunc {
 	// Normalize configured domains to ASCII (Punycode) for consistent comparison,
 	// matching the normalization that autocert.HostWhitelist applies via idna.Lookup.ToASCII.
@@ -172,7 +175,7 @@ func httpRedirectHandler(tlsDomains []string) http.HandlerFunc {
 
 		normalizedHost, err := idna.Lookup.ToASCII(host)
 		if err != nil {
-			slog.Warn("Rejecting request with host that failed IDNA normalization", "host", host, "error", err)
+			slog.Debug("Rejecting request with host that failed IDNA normalization", "host", host, "error", err)
 			http.Error(w, "Misdirected Request", http.StatusMisdirectedRequest)
 			return
 		}

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -57,6 +57,109 @@ func TestServerDefaultCannotMakeH2CRequest(t *testing.T) {
 	assert.Contains(t, err.Error(), "http2: failed reading the frame payload")
 }
 
+func TestHttpRedirectHandlerRejectsSpoofedHost(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://evil.example.com/path", nil)
+	req.Host = "evil.example.com"
+	recorder := httptest.NewRecorder()
+
+	handler := httpRedirectHandler([]string{"legit.example.com"})
+	handler.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusMisdirectedRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Misdirected Request")
+	assert.Empty(t, recorder.Header().Get("Location"))
+}
+
+func TestHttpRedirectHandlerAllowedDomainGets301(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://legit.example.com/path?q=1", nil)
+	req.Host = "legit.example.com"
+	recorder := httptest.NewRecorder()
+
+	handler := httpRedirectHandler([]string{"legit.example.com"})
+	handler.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
+	assert.Equal(t, "https://legit.example.com/path?q=1", recorder.Header().Get("Location"))
+}
+
+func TestHttpRedirectHandlerAllowedDomainWithPort(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://example.com:9877/path", nil)
+	req.Host = "example.com:9877"
+	recorder := httptest.NewRecorder()
+
+	handler := httpRedirectHandler([]string{"example.com"})
+	handler.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
+	assert.Equal(t, "https://example.com/path", recorder.Header().Get("Location"))
+}
+
+func TestHttpRedirectHandlerMultipleTLSDomains(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://second.example.com/", nil)
+	req.Host = "second.example.com"
+	recorder := httptest.NewRecorder()
+
+	handler := httpRedirectHandler([]string{"first.example.com", "second.example.com"})
+	handler.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
+	assert.Equal(t, "https://second.example.com/", recorder.Header().Get("Location"))
+}
+
+func TestHttpRedirectHandlerCaseInsensitiveMatch(t *testing.T) {
+	req := httptest.NewRequest("GET", "http://example.com/", nil)
+	req.Host = "example.com"
+	recorder := httptest.NewRecorder()
+
+	handler := httpRedirectHandler([]string{"Example.COM"})
+	handler.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
+	assert.Equal(t, "https://example.com/", recorder.Header().Get("Location"))
+}
+
+func TestHttpRedirectHandlerIDNDomain(t *testing.T) {
+	// Configure with a unicode domain; the handler normalizes it to Punycode
+	// for comparison, matching autocert.HostWhitelist behavior.
+	handler := httpRedirectHandler([]string{"\u00fc\u00f6\u00e4.example.com"})
+
+	t.Run("unicode host matches unicode config", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "http://xn--4ca9ar.example.com/", nil)
+		req.Host = "\u00fc\u00f6\u00e4.example.com"
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
+	})
+
+	t.Run("punycode host matches unicode config", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "http://xn--4ca9ar.example.com/", nil)
+		req.Host = "xn--4ca9ar.example.com"
+		recorder := httptest.NewRecorder()
+
+		handler.ServeHTTP(recorder, req)
+
+		assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
+	})
+}
+
+func TestHttpRedirectHandlerRejectsHostFailingIDNANormalization(t *testing.T) {
+	handler := httpRedirectHandler([]string{"legit.example.com"})
+
+	// A leading hyphen in a label violates IDNA2008 label validation rules,
+	// causing idna.Lookup.ToASCII to return an error.
+	req := httptest.NewRequest("GET", "http://legit.example.com/", nil)
+	req.Host = "-invalid-.example.com"
+	recorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(recorder, req)
+
+	assert.Equal(t, http.StatusMisdirectedRequest, recorder.Code)
+	assert.Contains(t, recorder.Body.String(), "Misdirected Request")
+	assert.Empty(t, recorder.Header().Get("Location"))
+}
+
 func makeRoundTripH2cRequest(t *testing.T, h2cEnabled bool) (*http.Response, error) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "HTTP/1.1", r.Proto, "The upstream should still be serving http/1.1")

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -131,6 +131,7 @@ func TestHttpRedirectHandlerIDNDomain(t *testing.T) {
 		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
+		assert.Equal(t, "https://xn--4ca9ar.example.com/", recorder.Header().Get("Location"))
 	})
 
 	t.Run("punycode host matches unicode config", func(t *testing.T) {
@@ -141,6 +142,7 @@ func TestHttpRedirectHandlerIDNDomain(t *testing.T) {
 		handler.ServeHTTP(recorder, req)
 
 		assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
+		assert.Equal(t, "https://xn--4ca9ar.example.com/", recorder.Header().Get("Location"))
 	})
 }
 

--- a/internal/server_test.go
+++ b/internal/server_test.go
@@ -57,111 +57,6 @@ func TestServerDefaultCannotMakeH2CRequest(t *testing.T) {
 	assert.Contains(t, err.Error(), "http2: failed reading the frame payload")
 }
 
-func TestHttpRedirectHandlerRejectsSpoofedHost(t *testing.T) {
-	req := httptest.NewRequest("GET", "http://evil.example.com/path", nil)
-	req.Host = "evil.example.com"
-	recorder := httptest.NewRecorder()
-
-	handler := httpRedirectHandler([]string{"legit.example.com"})
-	handler.ServeHTTP(recorder, req)
-
-	assert.Equal(t, http.StatusMisdirectedRequest, recorder.Code)
-	assert.Contains(t, recorder.Body.String(), "Misdirected Request")
-	assert.Empty(t, recorder.Header().Get("Location"))
-}
-
-func TestHttpRedirectHandlerAllowedDomainGets301(t *testing.T) {
-	req := httptest.NewRequest("GET", "http://legit.example.com/path?q=1", nil)
-	req.Host = "legit.example.com"
-	recorder := httptest.NewRecorder()
-
-	handler := httpRedirectHandler([]string{"legit.example.com"})
-	handler.ServeHTTP(recorder, req)
-
-	assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
-	assert.Equal(t, "https://legit.example.com/path?q=1", recorder.Header().Get("Location"))
-}
-
-func TestHttpRedirectHandlerAllowedDomainWithPort(t *testing.T) {
-	req := httptest.NewRequest("GET", "http://example.com:9877/path", nil)
-	req.Host = "example.com:9877"
-	recorder := httptest.NewRecorder()
-
-	handler := httpRedirectHandler([]string{"example.com"})
-	handler.ServeHTTP(recorder, req)
-
-	assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
-	assert.Equal(t, "https://example.com/path", recorder.Header().Get("Location"))
-}
-
-func TestHttpRedirectHandlerMultipleTLSDomains(t *testing.T) {
-	req := httptest.NewRequest("GET", "http://second.example.com/", nil)
-	req.Host = "second.example.com"
-	recorder := httptest.NewRecorder()
-
-	handler := httpRedirectHandler([]string{"first.example.com", "second.example.com"})
-	handler.ServeHTTP(recorder, req)
-
-	assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
-	assert.Equal(t, "https://second.example.com/", recorder.Header().Get("Location"))
-}
-
-func TestHttpRedirectHandlerCaseInsensitiveMatch(t *testing.T) {
-	req := httptest.NewRequest("GET", "http://example.com/", nil)
-	req.Host = "example.com"
-	recorder := httptest.NewRecorder()
-
-	handler := httpRedirectHandler([]string{"Example.COM"})
-	handler.ServeHTTP(recorder, req)
-
-	assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
-	assert.Equal(t, "https://example.com/", recorder.Header().Get("Location"))
-}
-
-func TestHttpRedirectHandlerIDNDomain(t *testing.T) {
-	// Configure with a unicode domain; the handler normalizes it to Punycode
-	// for comparison, matching autocert.HostWhitelist behavior.
-	handler := httpRedirectHandler([]string{"\u00fc\u00f6\u00e4.example.com"})
-
-	t.Run("unicode host matches unicode config", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "http://xn--4ca9ar.example.com/", nil)
-		req.Host = "\u00fc\u00f6\u00e4.example.com"
-		recorder := httptest.NewRecorder()
-
-		handler.ServeHTTP(recorder, req)
-
-		assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
-		assert.Equal(t, "https://xn--4ca9ar.example.com/", recorder.Header().Get("Location"))
-	})
-
-	t.Run("punycode host matches unicode config", func(t *testing.T) {
-		req := httptest.NewRequest("GET", "http://xn--4ca9ar.example.com/", nil)
-		req.Host = "xn--4ca9ar.example.com"
-		recorder := httptest.NewRecorder()
-
-		handler.ServeHTTP(recorder, req)
-
-		assert.Equal(t, http.StatusMovedPermanently, recorder.Code)
-		assert.Equal(t, "https://xn--4ca9ar.example.com/", recorder.Header().Get("Location"))
-	})
-}
-
-func TestHttpRedirectHandlerRejectsHostFailingIDNANormalization(t *testing.T) {
-	handler := httpRedirectHandler([]string{"legit.example.com"})
-
-	// A leading hyphen in a label violates IDNA2008 label validation rules,
-	// causing idna.Lookup.ToASCII to return an error.
-	req := httptest.NewRequest("GET", "http://legit.example.com/", nil)
-	req.Host = "-invalid-.example.com"
-	recorder := httptest.NewRecorder()
-
-	handler.ServeHTTP(recorder, req)
-
-	assert.Equal(t, http.StatusMisdirectedRequest, recorder.Code)
-	assert.Contains(t, recorder.Body.String(), "Misdirected Request")
-	assert.Empty(t, recorder.Header().Get("Location"))
-}
-
 func makeRoundTripH2cRequest(t *testing.T, h2cEnabled bool) (*http.Response, error) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "HTTP/1.1", r.Proto, "The upstream should still be serving http/1.1")
@@ -196,4 +91,68 @@ func makeRoundTripH2cRequest(t *testing.T, h2cEnabled bool) (*http.Response, err
 	}
 
 	return client.Get(fmt.Sprintf("http://%s/", listener.Addr()))
+}
+
+func TestHttpRedirect(t *testing.T) {
+	s := &Server{
+		config: &Config{
+			TLSDomains:  []string{"example.com", "café.example.com"},
+			StoragePath: t.TempDir(),
+		},
+	}
+	s.manager = s.certManager()
+
+	redirect := func(url string) *httptest.ResponseRecorder {
+		t.Helper()
+		w := httptest.NewRecorder()
+		s.httpRedirectHandler(w, httptest.NewRequest("GET", url, nil))
+		return w
+	}
+
+	t.Run("disallowed host", func(t *testing.T) {
+		w := redirect("http://evil.com/path")
+
+		assert.Equal(t, http.StatusMisdirectedRequest, w.Code)
+	})
+
+	t.Run("allowed host", func(t *testing.T) {
+		w := redirect("http://example.com/path")
+
+		assert.Equal(t, http.StatusMovedPermanently, w.Code)
+		assert.Equal(t, "https://example.com/path", w.Header().Get("Location"))
+	})
+
+	t.Run("allowed host with explicit port", func(t *testing.T) {
+		w := redirect("http://example.com:80/path")
+
+		assert.Equal(t, http.StatusMovedPermanently, w.Code)
+		assert.Equal(t, "https://example.com/path", w.Header().Get("Location"))
+	})
+
+	t.Run("mixed case allowed host", func(t *testing.T) {
+		w := redirect("http://Example.COM/path")
+
+		assert.Equal(t, http.StatusMovedPermanently, w.Code)
+		assert.Equal(t, "https://example.com/path", w.Header().Get("Location"))
+	})
+
+	t.Run("unicode host", func(t *testing.T) {
+		w := redirect("http://café.example.com/path")
+
+		assert.Equal(t, http.StatusMovedPermanently, w.Code)
+		assert.Equal(t, "https://xn--caf-dma.example.com/path", w.Header().Get("Location"))
+	})
+
+	t.Run("unicode host using punycode", func(t *testing.T) {
+		w := redirect("http://xn--caf-dma.example.com/path")
+
+		assert.Equal(t, http.StatusMovedPermanently, w.Code)
+		assert.Equal(t, "https://xn--caf-dma.example.com/path", w.Header().Get("Location"))
+	})
+
+	t.Run("unicode host using invalid punycode", func(t *testing.T) {
+		w := redirect("http://-xn--caf-dma.example.com/path")
+
+		assert.Equal(t, http.StatusMisdirectedRequest, w.Code)
+	})
 }


### PR DESCRIPTION
## Summary

- The `httpRedirectHandler` built the redirect `Location` header directly from the client-supplied `Host` header without checking it against the configured `TLS_DOMAIN` allowlist. A spoofed `Host` header would produce a `301` redirect to `https://<spoofed-host>/...`.
- The handler now validates the request `Host` against configured TLS domains before redirecting, returning `421 Misdirected Request` for unrecognized hosts.
- Both configured domains and incoming hosts are normalized via `idna.Lookup.ToASCII` to match the normalization that `autocert.HostWhitelist` applies for certificate issuance. Hosts or configured domains that fail IDNA normalization are rejected/skipped.

## Test plan

- [x] Spoofed host gets 421 Misdirected Request (not 301)
- [x] Allowed domain gets 301 redirect with correct Location
- [x] Allowed domain with port gets 301 redirect (port stripped, HTTPS defaults to 443)
- [x] Multiple TLS domains work correctly
- [x] Case-insensitive domain matching (via IDNA normalization)
- [x] Unicode/Punycode IDN domains match correctly
- [x] Host failing IDNA normalization gets 421
- [x] Full test suite passes

ref: https://3.basecamp.com/2914079/buckets/1666/card_tables/cards/9714031628

Reported by @Pa345-ai 

🤖 Generated with [Claude Code](https://claude.com/claude-code)