### PR TITLE
Drain HTTP server before relaying termination signal to upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ environment variables that you can set.
 | `HTTP_IDLE_TIMEOUT`         | The maximum time in seconds that a client can be idle before the connection is closed. | 60 |
 | `HTTP_READ_TIMEOUT`         | The maximum time in seconds that a client can take to send the request headers and body. | 30 |
 | `HTTP_WRITE_TIMEOUT`        | The maximum time in seconds during which the client must read the response. | 30 |
+| `HTTP_DRAIN_TIMEOUT`        | When shutting down, the maximum time in seconds to wait for in-flight requests to finish before relaying the termination signal to your server. New connections are refused as soon as draining begins. Should generally be at least as long as your read and write timeouts. | 30 |
 | `H2C_ENABLED`               | Set to `1` or `true` to enable h2c (http/2 cleartext) | Disabled |
 | `ACME_DIRECTORY`            | The URL of the ACME directory to use for TLS certificate provisioning. | `https://acme-v02.api.letsencrypt.org/directory` (Let's Encrypt production) |
 | `EAB_KID`                   | The EAB key identifier to use when provisioning TLS certificates, if required. | None |

--- a/internal/config.go
+++ b/internal/config.go
@@ -32,6 +32,7 @@ const (
 	defaultHttpIdleTimeout  = 60 * time.Second
 	defaultHttpReadTimeout  = 30 * time.Second
 	defaultHttpWriteTimeout = 30 * time.Second
+	defaultHttpDrainTimeout = 30 * time.Second
 
 	defaultH2CEnabled = false
 
@@ -67,6 +68,7 @@ type Config struct {
 	HttpIdleTimeout  time.Duration
 	HttpReadTimeout  time.Duration
 	HttpWriteTimeout time.Duration
+	HttpDrainTimeout time.Duration
 
 	H2CEnabled bool
 
@@ -111,6 +113,7 @@ func NewConfig() (*Config, error) {
 		HttpIdleTimeout:  getEnvDuration("HTTP_IDLE_TIMEOUT", defaultHttpIdleTimeout),
 		HttpReadTimeout:  getEnvDuration("HTTP_READ_TIMEOUT", defaultHttpReadTimeout),
 		HttpWriteTimeout: getEnvDuration("HTTP_WRITE_TIMEOUT", defaultHttpWriteTimeout),
+		HttpDrainTimeout: getEnvDuration("HTTP_DRAIN_TIMEOUT", defaultHttpDrainTimeout),
 
 		H2CEnabled: getEnvBool("H2C_ENABLED", defaultH2CEnabled),
 

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -106,6 +106,7 @@ func TestConfig_defaults(t *testing.T) {
 	assert.Equal(t, defaultCacheSize, c.CacheSizeBytes)
 	assert.Equal(t, slog.LevelInfo, c.LogLevel)
 	assert.Equal(t, false, c.H2CEnabled)
+	assert.Equal(t, 30*time.Second, c.HttpDrainTimeout)
 }
 
 func TestConfig_override_defaults_with_env_vars(t *testing.T) {
@@ -113,6 +114,7 @@ func TestConfig_override_defaults_with_env_vars(t *testing.T) {
 	usingEnvVar(t, "TARGET_PORT", "4000")
 	usingEnvVar(t, "CACHE_SIZE", "256")
 	usingEnvVar(t, "HTTP_READ_TIMEOUT", "5")
+	usingEnvVar(t, "HTTP_DRAIN_TIMEOUT", "10")
 	usingEnvVar(t, "X_SENDFILE_ENABLED", "0")
 	usingEnvVar(t, "GZIP_COMPRESSION_ENABLED", "0")
 	usingEnvVar(t, "DEBUG", "1")
@@ -128,6 +130,7 @@ func TestConfig_override_defaults_with_env_vars(t *testing.T) {
 	assert.Equal(t, 4000, c.TargetPort)
 	assert.Equal(t, 256, c.CacheSizeBytes)
 	assert.Equal(t, 5*time.Second, c.HttpReadTimeout)
+	assert.Equal(t, 10*time.Second, c.HttpDrainTimeout)
 	assert.Equal(t, false, c.XSendfileEnabled)
 	assert.Equal(t, false, c.GzipCompressionEnabled)
 	assert.Equal(t, slog.LevelDebug, c.LogLevel)

--- a/internal/server.go
+++ b/internal/server.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
-	"time"
+	"sync"
 
 	"golang.org/x/crypto/acme"
 	"golang.org/x/crypto/acme/autocert"
@@ -20,6 +20,7 @@ type Server struct {
 	httpServer  *http.Server
 	httpsServer *http.Server
 	manager     *autocert.Manager
+	stopOnce    sync.Once
 }
 
 func NewServer(config *Config, handler http.Handler) *Server {
@@ -79,17 +80,25 @@ func (s *Server) Start() error {
 	}
 }
 
+// Stop gracefully shuts down the HTTP server(s): it closes the listeners so we
+// stop accepting new connections, then waits up to HttpDrainTimeout for
+// in-flight requests to finish. It is safe to call more than once -- only the
+// first call has any effect -- so that shutdown can be triggered both by a
+// termination signal and by the deferred cleanup in Service.Run without
+// shutting down twice.
 func (s *Server) Stop() {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-	defer cancel()
-	defer slog.Info("Server stopped")
+	s.stopOnce.Do(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), s.config.HttpDrainTimeout)
+		defer cancel()
+		defer slog.Info("Server stopped")
 
-	slog.Info("Server stopping")
+		slog.Info("Server stopping")
 
-	_ = s.httpServer.Shutdown(ctx)
-	if s.httpsServer != nil {
-		_ = s.httpsServer.Shutdown(ctx)
-	}
+		_ = s.httpServer.Shutdown(ctx)
+		if s.httpsServer != nil {
+			_ = s.httpsServer.Shutdown(ctx)
+		}
+	})
 }
 
 func (s *Server) certManager() *autocert.Manager {

--- a/internal/service.go
+++ b/internal/service.go
@@ -5,6 +5,8 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"os/signal"
+	"syscall"
 )
 
 type Service struct {
@@ -43,7 +45,11 @@ func (s *Service) Run() int {
 
 	s.setEnvironment()
 
+	stopped := make(chan struct{})
+	go s.handleSignals(server, upstream, stopped)
+
 	exitCode, err := upstream.Run()
+	close(stopped)
 	if err != nil {
 		slog.Error("Failed to start wrapped process", "command", s.config.UpstreamCommand, "args", s.config.UpstreamArgs, "error", err)
 		return 1
@@ -53,6 +59,48 @@ func (s *Service) Run() int {
 }
 
 // Private
+
+type signaler interface {
+	Signal(os.Signal) error
+}
+
+// handleSignals waits for a termination signal and then shuts down. It only
+// arms signal handling once the upstream process has started, so that a signal
+// arriving during startup keeps the default behaviour of terminating the
+// process rather than trying to signal an upstream that doesn't exist yet. It
+// returns (releasing the signal handler) when the upstream exits without a
+// signal, signalled by stopped being closed, so it doesn't outlive the service.
+func (s *Service) handleSignals(server *Server, upstream *UpstreamProcess, stopped <-chan struct{}) {
+	select {
+	case <-upstream.Started:
+	case <-stopped:
+		return
+	}
+
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(ch)
+
+	select {
+	case sig := <-ch:
+		gracefulShutdown(server, upstream, sig)
+	case <-stopped:
+	}
+}
+
+// gracefulShutdown drains the HTTP server before relaying the signal to the
+// upstream process. The order matters: draining first closes the listener so
+// we stop accepting new connections and let in-flight requests finish, while
+// the upstream is still able to serve them. Relaying the signal first would
+// leave a window where we keep accepting connections but the upstream has
+// already stopped listening, which surfaces to clients as 502s on every deploy.
+func gracefulShutdown(server *Server, upstream signaler, sig os.Signal) {
+	slog.Info("Draining HTTP server before relaying signal to upstream", "signal", sig.String())
+	server.Stop()
+	if err := upstream.Signal(sig); err != nil {
+		slog.Warn("Failed to relay signal to upstream", "signal", sig.String(), "error", err)
+	}
+}
 
 func (s *Service) cache() Cache {
 	return NewMemoryCache(s.config.CacheSizeBytes, s.config.MaxCacheItemSizeBytes)

--- a/internal/service_test.go
+++ b/internal/service_test.go
@@ -1,0 +1,115 @@
+package internal
+
+import (
+	"errors"
+	"net"
+	"net/http"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// gracefulShutdown must stop the HTTP server accepting new connections before
+// it relays the termination signal to the upstream process. Otherwise there is
+// a window during shutdown where we accept connections that the upstream --
+// already signalled to stop -- can no longer serve, which surfaces to clients
+// as 502s.
+func TestGracefulShutdownDrainsServerBeforeSignalingUpstream(t *testing.T) {
+	config := &Config{HttpDrainTimeout: 5 * time.Second}
+	server, address := serveOnRandomPort(t, config, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Stop()
+
+	require.True(t, accepting(address), "server should be accepting connections before shutdown")
+
+	upstream := &probingSignaler{probeAddress: address}
+	gracefulShutdown(server, upstream, syscall.SIGTERM)
+
+	require.True(t, upstream.signalled, "upstream should have been signalled")
+	assert.Equal(t, syscall.SIGTERM, upstream.signal)
+	assert.False(t, upstream.acceptingWhenSignalled,
+		"HTTP listener must be closed before the upstream is signalled")
+}
+
+// Even if relaying the signal to the upstream fails, the HTTP server must still
+// have been drained.
+func TestGracefulShutdownDrainsServerEvenWhenSignalingUpstreamFails(t *testing.T) {
+	config := &Config{HttpDrainTimeout: 5 * time.Second}
+	server, address := serveOnRandomPort(t, config, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer server.Stop()
+
+	upstream := &probingSignaler{probeAddress: address, err: errors.New("os: process already finished")}
+	gracefulShutdown(server, upstream, syscall.SIGTERM)
+
+	assert.True(t, upstream.signalled)
+	assert.False(t, accepting(address), "server should be drained even when signalling the upstream fails")
+}
+
+// handleSignals must release its signal handler and return when the upstream
+// exits on its own (no termination signal), rather than leaking a goroutine
+// that keeps intercepting signals for the rest of the process's life.
+func TestHandleSignalsReturnsWhenUpstreamExitsWithoutSignal(t *testing.T) {
+	upstream := &UpstreamProcess{Started: make(chan struct{}, 1)}
+	upstream.Started <- struct{}{} // the upstream has started
+
+	stopped := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		(&Service{}).handleSignals(nil, upstream, stopped)
+		close(done)
+	}()
+
+	close(stopped) // the upstream exited without a termination signal
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handleSignals did not return after the upstream stopped")
+	}
+}
+
+// serveOnRandomPort starts the server on an OS-assigned port using its own
+// listener, so the bound address is known without a free-port-then-rebind race.
+func serveOnRandomPort(t *testing.T, config *Config, handler http.Handler) (*Server, string) {
+	t.Helper()
+
+	server := NewServer(config, handler)
+	server.httpServer = server.defaultHttpServer("127.0.0.1:0")
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	go func() { _ = server.httpServer.Serve(listener) }()
+
+	return server, listener.Addr().String()
+}
+
+// probingSignaler records, at the moment it is signalled, whether the HTTP
+// front-end is still accepting connections.
+type probingSignaler struct {
+	probeAddress           string
+	err                    error
+	signalled              bool
+	signal                 os.Signal
+	acceptingWhenSignalled bool
+}
+
+func (p *probingSignaler) Signal(sig os.Signal) error {
+	p.signalled = true
+	p.signal = sig
+	p.acceptingWhenSignalled = accepting(p.probeAddress)
+	return p.err
+}
+
+func accepting(address string) bool {
+	conn, err := net.DialTimeout("tcp", address, 200*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/internal/upstream_process.go
+++ b/internal/upstream_process.go
@@ -2,10 +2,8 @@ package internal
 
 import (
 	"errors"
-	"log/slog"
 	"os"
 	"os/exec"
-	"os/signal"
 	"syscall"
 )
 
@@ -33,7 +31,6 @@ func (p *UpstreamProcess) Run() (int, error) {
 
 	p.Started <- struct{}{}
 
-	go p.handleSignals()
 	err = p.cmd.Wait()
 
 	return p.handleExitCode(err)
@@ -41,15 +38,6 @@ func (p *UpstreamProcess) Run() (int, error) {
 
 func (p *UpstreamProcess) Signal(sig os.Signal) error {
 	return p.cmd.Process.Signal(sig)
-}
-
-func (p *UpstreamProcess) handleSignals() {
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
-
-	sig := <-ch
-	slog.Info("Relaying signal to upstream process", "signal", sig.String())
-	_ = p.Signal(sig)
 }
 
 func (p *UpstreamProcess) handleExitCode(err error) (int, error) {


### PR DESCRIPTION
## Problem

On `SIGTERM`/`SIGINT`, Thruster relays the signal straight to the upstream process and only closes its own HTTP listener afterwards, via the deferred `server.Stop()` in `Service.Run` — which doesn't run until `upstream.Run()` returns, i.e. until the upstream has already exited.

That leaves a window, for the entire duration of the upstream's shutdown (typically tens of seconds while it drains in-flight requests), where Thruster still accepts new connections on its HTTP port but the upstream has stopped listening. Each such connection fails at the proxy hop with `connection refused` and is returned to the client as a `502`. On a busy service this produces a burst of user-facing 502s on every deploy.

## Change

Reverse the order: intercept the signal in the `Service`, drain the HTTP server **first** — closing the listener so new connections are refused at the TCP level (where an upstream load balancer routes them elsewhere) while in-flight requests finish against the still-running upstream — and only **then** relay the signal to the upstream.

- Signal handling moves from `UpstreamProcess` to `Service`, which owns both the server and the upstream and so is the natural place to coordinate their shutdown order.
- `Server.Stop` is made idempotent, since it is now called both from the signal handler and from the deferred cleanup in `Run`.
- The drain timeout was previously hardcoded at 5s — which never mattered, since the listener wasn't closed until the upstream had already exited. Now that it is meaningful, it is configurable via `HTTP_DRAIN_TIMEOUT`, defaulting to 30s to match kamal-proxy's `--drain-timeout`.

## Before / after

Wrapping a backend that releases its port on `SIGTERM` and then takes a few seconds to exit (as Puma does while draining), while hammering the front-end during the shutdown window:

- **Before:** every request during the window → `502` (`dial tcp ...: connect: connection refused`)
- **After:** every request during the window → TCP connection refused, no 5xx; in-flight requests continue to drain via `http.Server.Shutdown`

## Tests

Adds `service_test.go` asserting the HTTP listener stops accepting connections before the upstream is signalled, plus config coverage for the new `HTTP_DRAIN_TIMEOUT` setting.
