### PR TITLE
Bypass all uncacheable requests

### DIFF
--- a/internal/cache_handler.go
+++ b/internal/cache_handler.go
@@ -44,6 +44,11 @@ func NewCacheHandler(cache Cache, maxBodySize int, next http.Handler) *CacheHand
 }
 
 func (h *CacheHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !h.shouldCacheRequest(r) {
+		h.bypassCache(w, r)
+		return
+	}
+
 	variant := NewVariant(r)
 	response, key, found := h.fetchFromCache(r, variant)
 
@@ -59,7 +64,7 @@ func (h *CacheHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !h.shouldCacheRequest(r) || !key.isCacheable() {
+	if !key.isCacheable() {
 		h.bypassCache(w, r)
 		return
 	}

--- a/internal/cache_handler_test.go
+++ b/internal/cache_handler_test.go
@@ -253,6 +253,14 @@ func TestCacheHandler_range_requests_are_not_cached(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "/", nil)
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "miss", w.Header().Get("X-Cache"))
+	assert.Equal(t, 1, len(cache.items))
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/", nil)
 	r.Header.Set("Range", "bytes=0-1")
 	handler.ServeHTTP(w, r)
 
@@ -269,6 +277,30 @@ func TestCacheHandler_range_requests_are_not_cached(t *testing.T) {
 	assert.Equal(t, http.StatusPartialContent, w.Code)
 	assert.Equal(t, "4", w.Header().Get("Content-Length"))
 	assert.Equal(t, fixtureContent("image.jpg")[2:6], w.Body.Bytes())
+	assert.Equal(t, "bypass", w.Header().Get("X-Cache"))
+}
+
+func TestCacheHandler_upgrade_requests_bypass_the_cache(t *testing.T) {
+	cache := newTestCache()
+
+	handler := NewCacheHandler(cache, 1024, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		_, _ = w.Write([]byte("Hello"))
+	}))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, "miss", w.Header().Get("X-Cache"))
+	assert.Equal(t, 1, len(cache.items))
+
+	w = httptest.NewRecorder()
+	r = httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Connection", "Upgrade")
+	r.Header.Set("Upgrade", "websocket")
+	handler.ServeHTTP(w, r)
+
 	assert.Equal(t, "bypass", w.Header().Get("X-Cache"))
 }
 


### PR DESCRIPTION
Previously we checked whether a request was cacheable only after the cache lookup. A request with a Range or Upgrade header could therefore match an existing cache entry and be served the full cached response, ignoring the Range or the upgrade. Check the request before the lookup so uncacheable requests always bypass the cache.