### PR TITLE
Bump Go to 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/basecamp/thruster
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/klauspost/compress v1.18.6


### PR DESCRIPTION
Bumps the go directive in go.mod from 1.26.5 to 1.26.6 to pick up the latest Go security patches.

CI resolves the toolchain via `go-version-file: go.mod`, so no separate workflow change is needed.

Follows the pattern of the previous Go security bump in 2eb7870.