### PR TITLE
Add X-Request-ID header to requests and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ environment variables that you can set.
 | `ACME_DIRECTORY`            | The URL of the ACME directory to use for TLS certificate provisioning. | `https://acme-v02.api.letsencrypt.org/directory` (Let's Encrypt production) |
 | `EAB_KID`                   | The EAB key identifier to use when provisioning TLS certificates, if required. | None |
 | `EAB_HMAC_KEY`              | The Base64-encoded EAB HMAC key to use when provisioning TLS certificates, if required. | None |
-| `FORWARD_HEADERS`           | Whether to forward X-Forwarded-* headers from the client. | Disabled when running with TLS; enabled otherwise |
+| `FORWARD_HEADERS`           | Whether to forward X-Forwarded-* and X-Request-ID headers from the client. | Disabled when running with TLS; enabled otherwise |
 | `LOG_REQUESTS`              | Log all requests. Set to `0` or `false` to disable request logging | Enabled |
 | `DEBUG`                     | Set to `1` or `true` to enable debug logging. | Disabled |
 

--- a/internal/cache_handler.go
+++ b/internal/cache_handler.go
@@ -79,10 +79,10 @@ func (h *CacheHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 		encoded, err := cr.ToBuffer()
 		if err != nil {
-			slog.Error("Failed to encode response for caching", "path", r.URL.Path, "error", err)
+			slog.Error("Failed to encode response for caching", "request_id", loggableRequestID(r), "path", r.URL.Path, "error", err)
 		} else {
 			h.cache.Set(key, encoded, expires)
-			slog.Debug("Added response to cache", "path", r.URL.Path, "expires", expires, "size", len(encoded))
+			slog.Debug("Added response to cache", "request_id", loggableRequestID(r), "path", r.URL.Path, "expires", expires, "size", len(encoded))
 		}
 	}
 }
@@ -90,7 +90,7 @@ func (h *CacheHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // Private
 
 func (h *CacheHandler) bypassCache(w http.ResponseWriter, r *http.Request) {
-	slog.Debug("Bypassing cache for request", "path", r.URL.Path, "method", r.Method)
+	slog.Debug("Bypassing cache for request", "request_id", loggableRequestID(r), "path", r.URL.Path, "method", r.Method)
 	w.Header().Set("X-Cache", "bypass")
 	h.next.ServeHTTP(w, r)
 }
@@ -106,7 +106,7 @@ func (h *CacheHandler) fetchFromCache(r *http.Request, variant *Variant) (Cachea
 	if found {
 		response, err := CacheableResponseFromBuffer(cached)
 		if err != nil {
-			slog.Error("Failed to decode cached response", "path", r.URL.Path, "error", err)
+			slog.Error("Failed to decode cached response", "request_id", loggableRequestID(r), "path", r.URL.Path, "error", err)
 			return CacheableResponse{}, key, false
 		}
 

--- a/internal/cacheable_response.go
+++ b/internal/cacheable_response.go
@@ -126,7 +126,7 @@ func (c *CacheableResponse) WriteCachedResponse(w http.ResponseWriter, r *http.R
 		c.copyHeaders(w, true, c.StatusCode)
 		_, err := io.Copy(w, bytes.NewReader(c.Body))
 		if err != nil {
-			slog.Error("Error writing cached response body", "error", err)
+			slog.Error("Error writing cached response body", "request_id", loggableRequestID(r), "error", err)
 		}
 	}
 }

--- a/internal/handler.go
+++ b/internal/handler.go
@@ -25,6 +25,7 @@ func NewHandler(options HandlerOptions) http.Handler {
 	handler = NewCacheHandler(options.cache, options.maxCacheableResponseBody, handler)
 	handler = NewSendfileHandler(options.xSendfileEnabled, handler)
 	handler = NewRequestStartHandler(handler)
+	handler = NewRequestIDHandler(options.forwardHeaders, handler)
 
 	if options.gzipCompressionEnabled {
 		handler = NewCompressionHandler(options.gzipCompressionJitter, options.gzipCompressionDisableOnAuth, handler)

--- a/internal/handler_test.go
+++ b/internal/handler_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+	"uuid"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -310,6 +311,110 @@ func TestHandlerAddsXRequestStartHeader(t *testing.T) {
 	h.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHandlerAddsXRequestIDHeader(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		header := r.Header.Get("X-Request-ID")
+		assert.NotEmpty(t, header, "X-Request-ID header should be present")
+		_, err := uuid.Parse(header)
+		assert.NoError(t, err, "X-Request-ID header should be a UUID")
+	}))
+	defer upstream.Close()
+
+	h := NewHandler(handlerOptions(upstream.URL))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHandlerForwardsExistingXRequestIDHeaderWhenForwardingEnabled(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "id-from-downstream", r.Header.Get("X-Request-ID"))
+	}))
+	defer upstream.Close()
+
+	h := NewHandler(handlerOptions(upstream.URL))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("X-Request-ID", "id-from-downstream")
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHandlerReplacesExistingXRequestIDHeaderWhenForwardingNotEnabled(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		header := r.Header.Get("X-Request-ID")
+		assert.NotEqual(t, "id-from-client", header)
+		_, err := uuid.Parse(header)
+		assert.NoError(t, err, "X-Request-ID header should be a UUID")
+	}))
+	defer upstream.Close()
+
+	options := handlerOptions(upstream.URL)
+	options.forwardHeaders = false
+	h := NewHandler(options)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("X-Request-ID", "id-from-client")
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestHandlerSetsXRequestIDResponseHeaderIgnoringUpstreamEcho(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Request-ID", "id-from-upstream")
+	}))
+	defer upstream.Close()
+
+	h := NewHandler(handlerOptions(upstream.URL))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	values := w.Header().Values("X-Request-ID")
+	assert.Len(t, values, 1)
+	_, err := uuid.Parse(values[0])
+	assert.NoError(t, err)
+}
+
+func TestHandlerSetsFreshXRequestIDOnCachedResponses(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		w.Header().Set("X-Request-ID", r.Header.Get("X-Request-ID"))
+		_, _ = w.Write([]byte("cacheable response"))
+	}))
+	defer upstream.Close()
+
+	h := NewHandler(handlerOptions(upstream.URL))
+
+	serveRequest := func() (string, string) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/", nil)
+		h.ServeHTTP(w, r)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		return w.Header().Get("X-Cache"), w.Header().Get("X-Request-ID")
+	}
+
+	firstCache, firstID := serveRequest()
+	secondCache, secondID := serveRequest()
+
+	assert.Equal(t, "miss", firstCache)
+	assert.Equal(t, "hit", secondCache)
+	assert.NotEmpty(t, firstID)
+	assert.NotEmpty(t, secondID)
+	assert.NotEqual(t, firstID, secondID)
 }
 
 func TestHandlerAllowsFlushingTheResponseBody(t *testing.T) {

--- a/internal/handler_test.go
+++ b/internal/handler_test.go
@@ -417,6 +417,23 @@ func TestHandlerSetsFreshXRequestIDOnCachedResponses(t *testing.T) {
 	assert.NotEqual(t, firstID, secondID)
 }
 
+func TestHandlerRestoresItsHeadersNamedInConnectionHeader(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NotEmpty(t, r.Header.Get("X-Request-ID"), "X-Request-ID header should be present")
+		assert.NotEmpty(t, r.Header.Get("X-Request-Start"), "X-Request-Start header should be present")
+	}))
+	defer upstream.Close()
+
+	h := NewHandler(handlerOptions(upstream.URL))
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Connection", "X-Request-ID, X-Request-Start")
+	h.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestHandlerAllowsFlushingTheResponseBody(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/internal/logging_handler.go
+++ b/internal/logging_handler.go
@@ -32,12 +32,14 @@ func (h *LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	reqContent := r.Header.Get("Content-Type")
 	respContent := writer.Header().Get("Content-Type")
 	cache := writer.Header().Get("X-Cache")
+	requestID := loggableRequestID(r)
 	remoteAddr := r.Header.Get("X-Forwarded-For")
 	if remoteAddr == "" {
 		remoteAddr = r.RemoteAddr
 	}
 
 	h.logger.Info("Request",
+		"request_id", requestID,
 		"path", r.URL.Path,
 		"status", writer.statusCode,
 		"dur", elapsed.Milliseconds(),

--- a/internal/logging_handler_test.go
+++ b/internal/logging_handler_test.go
@@ -28,10 +28,12 @@ func TestLoggingHandler(t *testing.T) {
 	req.Header.Set("X-Forwarded-For", "192.168.1.1")
 	req.Header.Set("User-Agent", "Robot/1")
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Request-ID", "test-request-id")
 
 	handler.ServeHTTP(httptest.NewRecorder(), req)
 
 	logline := struct {
+		RequestID         string `json:"request_id"`
 		Path              string `json:"path"`
 		Method            string `json:"method"`
 		Status            int    `json:"status"`
@@ -48,6 +50,7 @@ func TestLoggingHandler(t *testing.T) {
 	err := json.NewDecoder(strings.NewReader(out.String())).Decode(&logline)
 	require.NoError(t, err)
 
+	assert.Equal(t, "test-request-id", logline.RequestID)
 	assert.Equal(t, "/somepath", logline.Path)
 	assert.Equal(t, "POST", logline.Method)
 	assert.Equal(t, http.StatusCreated, logline.Status)

--- a/internal/proxy_handler.go
+++ b/internal/proxy_handler.go
@@ -14,7 +14,9 @@ func NewProxyHandler(targetUrl *url.URL, badGatewayPage string, forwardHeaders b
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.SetURL(targetUrl)
 			r.Out.Host = r.In.Host
+
 			setXForwarded(r, forwardHeaders)
+			restoreOwnedHeaders(r)
 		},
 		ModifyResponse: func(r *http.Response) error {
 			r.Header.Del("X-Request-ID") // We set our own in NewRequestIDHandler
@@ -59,12 +61,22 @@ func setXForwarded(r *httputil.ProxyRequest, forwardHeaders bool) {
 
 	if forwardHeaders {
 		// Preserve original headers if we had them
-		if r.In.Header.Get("X-Forwarded-Host") != "" {
-			r.Out.Header.Set("X-Forwarded-Host", r.In.Header.Get("X-Forwarded-Host"))
-		}
-		if r.In.Header.Get("X-Forwarded-Proto") != "" {
-			r.Out.Header.Set("X-Forwarded-Proto", r.In.Header.Get("X-Forwarded-Proto"))
-		}
+		transferHeader(r, "X-Forwarded-Host")
+		transferHeader(r, "X-Forwarded-Proto")
+	}
+}
+
+// ReverseProxy strips any header the client names in its Connection header,
+// as hop-by-hop. That's correct for the client's own headers, but not for the
+// ones we set ourselves, so restore those.
+func restoreOwnedHeaders(r *httputil.ProxyRequest) {
+	transferHeader(r, "X-Request-ID")
+	transferHeader(r, "X-Request-Start")
+}
+
+func transferHeader(r *httputil.ProxyRequest, name string) {
+	if value := r.In.Header.Get(name); value != "" {
+		r.Out.Header.Set(name, value)
 	}
 }
 

--- a/internal/proxy_handler.go
+++ b/internal/proxy_handler.go
@@ -16,6 +16,10 @@ func NewProxyHandler(targetUrl *url.URL, badGatewayPage string, forwardHeaders b
 			r.Out.Host = r.In.Host
 			setXForwarded(r, forwardHeaders)
 		},
+		ModifyResponse: func(r *http.Response) error {
+			r.Header.Del("X-Request-ID") // We set our own in NewRequestIDHandler
+			return nil
+		},
 		ErrorHandler: ProxyErrorHandler(badGatewayPage),
 		Transport:    createProxyTransport(),
 	}
@@ -29,7 +33,7 @@ func ProxyErrorHandler(badGatewayPage string) func(w http.ResponseWriter, r *htt
 	}
 
 	return func(w http.ResponseWriter, r *http.Request, err error) {
-		slog.Info("Unable to proxy request", "path", r.URL.Path, "error", err)
+		slog.Info("Unable to proxy request", "request_id", loggableRequestID(r), "path", r.URL.Path, "error", err)
 
 		if isRequestEntityTooLarge(err) {
 			w.WriteHeader(http.StatusRequestEntityTooLarge)

--- a/internal/request_id_handler.go
+++ b/internal/request_id_handler.go
@@ -1,0 +1,26 @@
+package internal
+
+import (
+	"net/http"
+	"uuid"
+)
+
+const maxLoggableRequestIDLength = 255
+
+func NewRequestIDHandler(trustClientHeader bool, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !trustClientHeader || r.Header.Get("X-Request-ID") == "" {
+			r.Header.Set("X-Request-ID", uuid.New().String())
+		}
+		w.Header().Set("X-Request-ID", r.Header.Get("X-Request-ID"))
+		next.ServeHTTP(w, r)
+	})
+}
+
+func loggableRequestID(r *http.Request) string {
+	id := r.Header.Get("X-Request-ID")
+	if len(id) > maxLoggableRequestIDLength {
+		id = id[:maxLoggableRequestIDLength]
+	}
+	return id
+}

--- a/internal/request_id_handler_test.go
+++ b/internal/request_id_handler_test.go
@@ -1,0 +1,74 @@
+package internal
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"uuid"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestIDHandlerAddsHeaderWhenMissing(t *testing.T) {
+	var capturedHeader string
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("X-Request-ID")
+	})
+
+	handler := NewRequestIDHandler(true, nextHandler)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.NotEmpty(t, capturedHeader)
+	_, err := uuid.Parse(capturedHeader)
+	assert.NoError(t, err)
+	assert.Equal(t, capturedHeader, w.Header().Get("X-Request-ID"))
+}
+
+func TestRequestIDHandlerPreservesExistingHeaderWhenTrusted(t *testing.T) {
+	existingHeader := "id-from-downstream"
+	var capturedHeader string
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("X-Request-ID")
+	})
+
+	handler := NewRequestIDHandler(true, nextHandler)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-ID", existingHeader)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.Equal(t, existingHeader, capturedHeader)
+	assert.Equal(t, capturedHeader, w.Header().Get("X-Request-ID"))
+}
+
+func TestRequestIDHandlerReplacesExistingHeaderWhenNotTrusted(t *testing.T) {
+	existingHeader := "id-from-client"
+	var capturedHeader string
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("X-Request-ID")
+	})
+
+	handler := NewRequestIDHandler(false, nextHandler)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Request-ID", existingHeader)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	assert.NotEqual(t, existingHeader, capturedHeader)
+	_, err := uuid.Parse(capturedHeader)
+	assert.NoError(t, err)
+	assert.Equal(t, capturedHeader, w.Header().Get("X-Request-ID"))
+}
+
+func TestLoggableRequestIDTruncatesLongValues(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("X-Request-ID", strings.Repeat("a", 300))
+
+	assert.Equal(t, strings.Repeat("a", 255), loggableRequestID(r))
+}

--- a/internal/sendfile_handler.go
+++ b/internal/sendfile_handler.go
@@ -91,7 +91,7 @@ func (w *sendfileWriter) sendingFilename() string {
 }
 
 func (w *sendfileWriter) serveFile(filename string) {
-	slog.Debug("X-Sendfile sending file", "path", filename)
+	slog.Debug("X-Sendfile sending file", "request_id", loggableRequestID(w.r), "path", filename)
 
 	w.setContentLength(filename)
 	http.ServeFile(w.w, w.r, filename)


### PR DESCRIPTION
Tag each request with an X-Request-ID header, so that the ID is available to the upstream server and recorded in our request logs as request_id.

When FORWARD_HEADERS is enabled, an ID supplied by a downstream proxy is kept, matching how we treat X-Forwarded-*.

Closes #139 